### PR TITLE
Update the cityhash package to its new location.

### DIFF
--- a/io/io_test.go
+++ b/io/io_test.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/list/list.go
+++ b/list/list.go
@@ -4,7 +4,7 @@ package list
 import (
 	"sync"
 
-	"bitbucket.org/creachadair/cityhash"
+	"github.com/creachadair/cityhash"
 )
 
 // List settings

--- a/reporters/reporters_test.go
+++ b/reporters/reporters_test.go
@@ -3,7 +3,8 @@ package reporters_test
 import (
 	"io/ioutil"
 
-	"github.com/bouk/monkey"
+	"bou.ke/monkey"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 


### PR DESCRIPTION
This package is being rehomed from bitbucket.org to github.com.
This commit updates the import path accordingly.
The version number has changed to reflect the import path change, but there is
otherwise no change to the package API.

~~N.B.: There is a unit test already failing at the head of master. This change does not make it any worse, but does not fix it either.~~

Edit: I was able to make Travis happy by fixing a canonical import path.